### PR TITLE
Reduce the amount of macro declarations needed.

### DIFF
--- a/reflite.h
+++ b/reflite.h
@@ -175,24 +175,15 @@ namespace reflite
 	}
 }
 
-#define REFLITE_TYPE(X) \
-inline static constexpr reflite::meta_type _metaType = { #X, reflite::cx_hash(#X) };
+#define REFLITE_START(X) \
+using self = X; \
+inline static constexpr reflite::meta_type _metaType = { #X, reflite::cx_hash(#X) }; \
+inline static std::tuple _metaData = {
 
-#define REFLITE_START \
-inline static std::tuple<
-
-#define REFLITE_ADD(TYPE, MEMBER_TYPE, NAME) \
-reflite::meta_data<TYPE, MEMBER_TYPE, reflite::cx_hash(NAME)>
+#define REFLITE_ADD(MEMBER) \
+reflite::meta_data<self, decltype(self::MEMBER), reflite::cx_hash(#MEMBER)> { #MEMBER, &self::MEMBER },
 
 #define REFLITE_END \
->_metaData = 
-
-#define REFLITE_DEFINE_START {
-
-#define REFLITE_DEFINE_ADD(TYPE, MEMBER, NAME) \
-{ NAME, &TYPE::MEMBER }
-
-#define REFLITE_DEFINE_END \
 };
 
 #define REFLITE_VISIT_START(TYPE, ELEMENT) \

--- a/sample.cpp
+++ b/sample.cpp
@@ -3,23 +3,14 @@
 
 struct Birthday
 {
-  // Members must be public
   int day = 1, month = 1, year = 1900;
 
   // Declare your reflections
-  REFLITE_TYPE(Birthday)
-  REFLITE_START
-  REFLITE_ADD(Birthday, int, "day"),
-  REFLITE_ADD(Birthday, int, "month"),
-  REFLITE_ADD(Birthday, int, "year")
+  REFLITE_START(Birthday)
+  REFLITE_ADD(day)
+  REFLITE_ADD(month)
+  REFLITE_ADD(year)
   REFLITE_END
-
-  // Define your reflections
-  REFLITE_DEFINE_START
-  REFLITE_DEFINE_ADD(Birthday, day, "day"),
-  REFLITE_DEFINE_ADD(Birthday, month, "month"),
-  REFLITE_DEFINE_ADD(Birthday, year, "year")
-  REFLITE_DEFINE_END
 };
 
 // Overload the operator<< for the std::cout below
@@ -30,25 +21,16 @@ std::ostream& operator<<(std::ostream& os, const Birthday& rhs)
 
 struct Human
 {
-  // Members must be public
   Birthday birthday;
   const char* name;
   float height;
 
   // Declare your reflections
-  REFLITE_TYPE(Human)
-  REFLITE_START
-  REFLITE_ADD(Human, Birthday, "birthday"),
-  REFLITE_ADD(Human, const char*, "name"),
-  REFLITE_ADD(Human, float, "height")
+  REFLITE_START(Human)
+  REFLITE_ADD(birthday)
+  REFLITE_ADD(name)
+  REFLITE_ADD(height)
   REFLITE_END
-  
-  // Define your reflections
-  REFLITE_DEFINE_START
-  REFLITE_DEFINE_ADD(Human, birthday, "birthday"),
-  REFLITE_DEFINE_ADD(Human, name, "name"),
-  REFLITE_DEFINE_ADD(Human, height, "height")
-  REFLITE_DEFINE_END
 };
 
 int main()


### PR DESCRIPTION
We can reduce the amount of macros needed by:
- saving the typename with `using` so you don't have to repeat it for every macro.
- using template argument deduction for `std::tuple` so we only have to define it (works since it's inline static)
- add `,` in the end, because initializer-lists can have trailing commas :)

Obviously more can be done, like you said, but this is a small change that can go a long way.
(Also, members don't have to be public..?)